### PR TITLE
Fix syntax for applying device tree overlays

### DIFF
--- a/boot.ini
+++ b/boot.ini
@@ -60,7 +60,7 @@ load mmc ${devno}:1 ${dtb_loadaddr} amlogic/meson64_odroid${variant}.dtb
 
 fdt addr ${dtb_loadaddr}
 
-if test "x{overlays}" != "x"; then
+if test "x${overlays}" != "x"; then
     fdt resize ${overlay_resize}
     for overlay in ${overlays}; do
         load mmc ${devno}:1 ${dtbo_addr_r} amlogic/overlays/${board}/${overlay}.dtbo \


### PR DESCRIPTION
Without this, the condition is always true, hence the device tree is resized even if no overlays have been set.